### PR TITLE
Feature delete empty log streams

### DIFF
--- a/PC Game Pass Notifier AWS Lambda/PC Game Pass Notifier AWS Lambda.csproj
+++ b/PC Game Pass Notifier AWS Lambda/PC Game Pass Notifier AWS Lambda.csproj
@@ -17,6 +17,7 @@
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
+    <PackageReference Include="AWSSDK.CloudWatchLogs" Version="3.7.2.71" />
     <PackageReference Include="AWSSDK.S3" Version="3.7.9.18" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>

--- a/PC Game Pass Notifier AWS Lambda/PcGamePassNotifier.cs
+++ b/PC Game Pass Notifier AWS Lambda/PcGamePassNotifier.cs
@@ -1,7 +1,9 @@
-﻿using System;
-using Amazon.Lambda.Core;
+﻿using Amazon.Lambda.Core;
 using Amazon.S3;
 using Amazon.S3.Model;
+using Amazon.CloudWatchLogs;
+using Amazon.CloudWatchLogs.Model;
+using System.Diagnostics.CodeAnalysis;
 using Newtonsoft.Json;
 
 // Assembly attribute to enable the Lambda function's JSON input to be converted into a .NET class.
@@ -11,7 +13,7 @@ namespace PC_Game_Pass_Notifier_AWS_Lambda;
 
 public class PcGamePassNotifier
 {
-	private static ILambdaContext? s_lambdaContext;
+	private static ILambdaContext s_lambdaContext;
 	private static readonly string s_gamePassGamesFileName = "pcGamePassGames.json";
 	private static readonly HttpClient s_httpClient = new();
 
@@ -23,31 +25,12 @@ public class PcGamePassNotifier
 
 	public static HttpClient HttpClient => s_httpClient;
 
+	[MemberNotNull(nameof(s_lambdaContext))]
 	public static async Task InitializeLambdaCall(Dictionary<string, string> inputJsonDictionary, ILambdaContext context)
 	{
 		s_lambdaContext = context;
 		await new PcGamePassNotifier(inputJsonDictionary).InitializeAndUpdateGamePassGames();
-	}
-
-	public static void LogInformation(string logString)
-	{
-		if (s_lambdaContext == null)
-			return;
-		s_lambdaContext.Logger.LogInformation(logString);
-	}
-
-	public static void LogError(string logString)
-	{
-		if (s_lambdaContext == null)
-			return;
-		s_lambdaContext.Logger.LogError(logString);
-	}
-
-	public static void LogWarning(string logString)
-	{
-		if (s_lambdaContext == null)
-			return;
-		s_lambdaContext.Logger.LogWarning(logString);
+		await DeleteEmptyLogStreams();
 	}
 
 	/// <summary>
@@ -90,6 +73,62 @@ public class PcGamePassNotifier
 		_gamePassGames = new Dictionary<string, GamePassGame>();
 		_s3Client = new AmazonS3Client(Amazon.RegionEndpoint.EUCentral1);
 		_bucketName = inputJsonDictionary.GetValueForKey("bucketName");
+	}
+
+	public static void LogInformation(string logString)
+	{
+		s_lambdaContext.Logger.LogInformation(logString);
+	}
+
+	public static void LogError(string logString)
+	{
+		s_lambdaContext.Logger.LogError(logString);
+	}
+
+	public static void LogWarning(string logString)
+	{
+		s_lambdaContext.Logger.LogWarning(logString);
+	}
+
+	private static async Task DeleteEmptyLogStreams()
+	{
+		var cloudWatchLogsClient = new AmazonCloudWatchLogsClient(Amazon.RegionEndpoint.EUCentral1);
+		var logGroupsRequest = new DescribeLogGroupsRequest()
+		{
+			LogGroupNamePrefix = s_lambdaContext.LogGroupName
+		};
+		DescribeLogGroupsResponse logGroupsResponse = await cloudWatchLogsClient.DescribeLogGroupsAsync(logGroupsRequest);
+		if (logGroupsResponse.LogGroups != null && logGroupsResponse.LogGroups.Count > 0)
+		{
+			LogGroup logGroup = logGroupsResponse.LogGroups.First();
+			var describeLogStreamsRequest = new DescribeLogStreamsRequest(s_lambdaContext.LogGroupName);
+			DescribeLogStreamsResponse response = await cloudWatchLogsClient.DescribeLogStreamsAsync(describeLogStreamsRequest);
+			List<LogStream> logStreamsToDelete = new();
+			foreach (LogStream logStream in response.LogStreams)
+			{
+				if ((DateTime.UtcNow - logStream.LastIngestionTime).TotalMilliseconds > (logGroup.RetentionInDays * 86400000)) // 1 day in milliseconds
+				{
+					logStreamsToDelete.Add(logStream);
+					LogInformation($"Added LogStream {logStream.LogStreamName} to deletion list");
+				}
+			}
+			LogInformation($"Start deletion of {logStreamsToDelete.Count} LogStreams");
+
+			// Don't actually delete yet, publish and evaluate logs first.
+
+			//List<Task> deleteTasks = new();
+			//foreach (LogStream logStream in logStreamsToDelete)
+			//{
+			//	var deleteLogStreamRequest = new DeleteLogStreamRequest()
+			//	{
+			//		LogGroupName = s_lambdaContext.LogGroupName,
+			//		LogStreamName = logStream.LogStreamName
+			//	};
+			//	deleteTasks.Add(cloudWatchLogsClient.DeleteLogStreamAsync(deleteLogStreamRequest));
+			//}
+			//await Task.WhenAll(deleteTasks);
+			//LogInformation($"{logStreamsToDelete.Count} LogStreams deleted");
+		}
 	}
 
 	public async Task InitializeAndUpdateGamePassGames()

--- a/PC Game Pass Notifier AWS Lambda/PcGamePassNotifier.cs
+++ b/PC Game Pass Notifier AWS Lambda/PcGamePassNotifier.cs
@@ -113,21 +113,30 @@ public class PcGamePassNotifier
 				}
 			}
 			LogInformation($"Start deletion of {logStreamsToDelete.Count} LogStreams");
-
-			// Don't actually delete yet, publish and evaluate logs first.
-
-			//List<Task> deleteTasks = new();
-			//foreach (LogStream logStream in logStreamsToDelete)
+			//// Don't actually delete yet, publish and evaluate logs first.
+			//int numberOfFailedDeletions = 0;
+			//try
 			//{
-			//	var deleteLogStreamRequest = new DeleteLogStreamRequest()
+			//	List<Task> deleteTasks = new();
+			//	foreach (LogStream logStream in logStreamsToDelete)
 			//	{
-			//		LogGroupName = s_lambdaContext.LogGroupName,
-			//		LogStreamName = logStream.LogStreamName
-			//	};
-			//	deleteTasks.Add(cloudWatchLogsClient.DeleteLogStreamAsync(deleteLogStreamRequest));
+			//		var deleteLogStreamRequest = new DeleteLogStreamRequest()
+			//		{
+			//			LogGroupName = s_lambdaContext.LogGroupName,
+			//			LogStreamName = logStream.LogStreamName
+			//		};
+			//		deleteTasks.Add(cloudWatchLogsClient.DeleteLogStreamAsync(deleteLogStreamRequest));
+			//	}
+			//	Task.WaitAll(deleteTasks.ToArray());
+			//} catch (AggregateException exception)
+			//{
+			//	foreach (var innerException in exception.InnerExceptions)
+			//	{
+			//		Console.WriteLine($"Caught exception during deletion: " + innerException.Message);
+			//		numberOfFailedDeletions++;
+			//	}
 			//}
-			//await Task.WhenAll(deleteTasks);
-			//LogInformation($"{logStreamsToDelete.Count} LogStreams deleted");
+			//LogInformation($"{logStreamsToDelete.Count - numberOfFailedDeletions} LogStreams deleted");
 		}
 	}
 

--- a/PC Game Pass Notifier AWS Lambda/PcGamePassNotifier.cs
+++ b/PC Game Pass Notifier AWS Lambda/PcGamePassNotifier.cs
@@ -13,7 +13,7 @@ namespace PC_Game_Pass_Notifier_AWS_Lambda;
 
 public class PcGamePassNotifier
 {
-	private static ILambdaContext s_lambdaContext;
+	private static ILambdaContext? s_lambdaContext;
 	private static readonly string s_gamePassGamesFileName = "pcGamePassGames.json";
 	private static readonly HttpClient s_httpClient = new();
 
@@ -77,21 +77,31 @@ public class PcGamePassNotifier
 
 	public static void LogInformation(string logString)
 	{
+		if (s_lambdaContext == null)
+			return;
 		s_lambdaContext.Logger.LogInformation(logString);
 	}
 
 	public static void LogError(string logString)
 	{
+		if (s_lambdaContext == null)
+			return;
 		s_lambdaContext.Logger.LogError(logString);
 	}
 
 	public static void LogWarning(string logString)
 	{
+		if (s_lambdaContext == null)
+			return;
 		s_lambdaContext.Logger.LogWarning(logString);
 	}
 
 	private static async Task DeleteEmptyLogStreams()
 	{
+		if (s_lambdaContext is null)
+		{
+			return;
+		}
 		var cloudWatchLogsClient = new AmazonCloudWatchLogsClient(Amazon.RegionEndpoint.EUCentral1);
 		var logGroupsRequest = new DescribeLogGroupsRequest()
 		{

--- a/PC Game Pass Notifier AWS Lambda/PcGamePassNotifier.cs
+++ b/PC Game Pass Notifier AWS Lambda/PcGamePassNotifier.cs
@@ -113,30 +113,29 @@ public class PcGamePassNotifier
 				}
 			}
 			LogInformation($"Start deletion of {logStreamsToDelete.Count} LogStreams");
-			//// Don't actually delete yet, publish and evaluate logs first.
-			//int numberOfFailedDeletions = 0;
-			//try
-			//{
-			//	List<Task> deleteTasks = new();
-			//	foreach (LogStream logStream in logStreamsToDelete)
-			//	{
-			//		var deleteLogStreamRequest = new DeleteLogStreamRequest()
-			//		{
-			//			LogGroupName = s_lambdaContext.LogGroupName,
-			//			LogStreamName = logStream.LogStreamName
-			//		};
-			//		deleteTasks.Add(cloudWatchLogsClient.DeleteLogStreamAsync(deleteLogStreamRequest));
-			//	}
-			//	Task.WaitAll(deleteTasks.ToArray());
-			//} catch (AggregateException exception)
-			//{
-			//	foreach (var innerException in exception.InnerExceptions)
-			//	{
-			//		Console.WriteLine($"Caught exception during deletion: " + innerException.Message);
-			//		numberOfFailedDeletions++;
-			//	}
-			//}
-			//LogInformation($"{logStreamsToDelete.Count - numberOfFailedDeletions} LogStreams deleted");
+			int numberOfFailedDeletions = 0;
+			try
+			{
+				List<Task> deleteTasks = new();
+				foreach (LogStream logStream in logStreamsToDelete)
+				{
+					var deleteLogStreamRequest = new DeleteLogStreamRequest()
+					{
+						LogGroupName = s_lambdaContext.LogGroupName,
+						LogStreamName = logStream.LogStreamName
+					};
+					deleteTasks.Add(cloudWatchLogsClient.DeleteLogStreamAsync(deleteLogStreamRequest));
+				}
+				Task.WaitAll(deleteTasks.ToArray());
+			} catch (AggregateException exception)
+			{
+				foreach (var innerException in exception.InnerExceptions)
+				{
+					LogError($"Caught exception during deletion: " + innerException.Message);
+					numberOfFailedDeletions++;
+				}
+			}
+			LogInformation($"{logStreamsToDelete.Count - numberOfFailedDeletions} LogStreams deleted");
 		}
 	}
 


### PR DESCRIPTION
The configured retention time in AWS CloudWatch Logs deletes logs older than the retention time, however it does not delete empty logStreams, when their logs are deleted.
Since AWS Lambda creates a new logStream for each invocation of a lambda function, this resulted in empty log streams piling up.
This feature iterates over all logStreams in the logGroup of the AWS Lambda function and deletes each logStream where the last ingestion time is older than the retention time configured for the logGroup. This way, we only have logStreams with logs.